### PR TITLE
Fix typo in error message.

### DIFF
--- a/modules/org.restlet.ext.sdc/src/org/restlet/ext/sdc/internal/SdcClientCall.java
+++ b/modules/org.restlet.ext.sdc/src/org/restlet/ext/sdc/internal/SdcClientCall.java
@@ -342,7 +342,7 @@ public class SdcClientCall extends ClientCall {
             getHelper()
                     .getLogger()
                     .log(Level.FINE,
-                            "An error occured during the communication with the remote HTTP server.",
+                            "An error occurred during the communication with the remote HTTP server.",
                             ioe);
             result = new Status(Status.CONNECTOR_ERROR_COMMUNICATION, ioe);
         } finally {

--- a/modules/org.restlet/src/org/restlet/engine/adapter/ServerAdapter.java
+++ b/modules/org.restlet/src/org/restlet/engine/adapter/ServerAdapter.java
@@ -196,11 +196,11 @@ public class ServerAdapter extends Adapter {
             // [enddef]
             {
                 getLogger().log(Level.SEVERE,
-                        "An exception occured writing the response entity", t);
+                        "An exception occurred writing the response entity", t);
                 response.getHttpCall().setStatusCode(
                         Status.SERVER_ERROR_INTERNAL.getCode());
                 response.getHttpCall().setReasonPhrase(
-                        "An exception occured writing the response entity");
+                        "An exception occurred writing the response entity");
                 response.setEntity(null);
 
                 try {


### PR DESCRIPTION
Our company uses Restlet 2.1 and noticed this typo in our logs quite a bit. Surprised it hasn't been fixed yet.